### PR TITLE
fixes in Governance by JFA

### DIFF
--- a/5._Governance.md
+++ b/5._Governance.md
@@ -63,7 +63,7 @@ The SWHID Project must adhere to consensus-based due process requirements. These
 
 The following describes the public process by which new versions of the SWHID Specification as a whole can be transitioned from Draft Specification to Approved Specification status.
 
-**5.1. Draft.** During the specification development process, Participants may submit issues and pull requests to the SWHID Specification repository. Pull requests will be merged upon Approval by the Editors. Each updated version of the SWHID Specification following the merging of a pull request will be considered a "Draft Specification".
+**5.1. Draft.** During the specification development process, Participants may submit issues and pull requests to the SWHID Specification repository. Pull requests will be merged upon Working Group approval by the Editors. Each updated version of the SWHID Specification following the merging of a pull request will be considered a "Draft Specification".
 
 **5.2. Process for Approved Specification status.** Upon the determination by the Core Team that it has achieved the objectives for its specification as described in the Scope, the Core Team will Approve that Draft Specification as a candidate for "Approved Specification" status.
 The following process will then be used:


### PR DESCRIPTION
- incorporates typo fixes by jfa
- Move the CoreTeam role before Editors
- Add that Maintainers document minority opinions (3.1)
- Updates point in Ways of Working, after jfa suggestions
- Specify the PR merge approval process (5.1)
